### PR TITLE
Fix favicon reference to point to existing favicon.svg

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>N.R Dhanawada - Solutions Architect & Platform Engineer</title>
     <meta name="description" content="N.R Dhanawada - Solutions Architect specializing in platform engineering, enterprise architecture, and building systems that help organizations serve people better." />


### PR DESCRIPTION
## Summary
- Updated the favicon `<link>` in `index.html` from `/vite.svg` (which doesn't exist) to `/favicon.svg` (which does)

## Test plan
- [ ] Verify favicon loads correctly in the browser tab

Closes #4