### PR TITLE
Fix webmanifest to reference existing favicon.svg

### DIFF
--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -3,14 +3,9 @@
     "short_name": "NRD",
     "icons": [
         {
-            "src": "/android-chrome-192x192.png",
-            "sizes": "192x192",
-            "type": "image/png"
-        },
-        {
-            "src": "/android-chrome-512x512.png",
-            "sizes": "512x512",
-            "type": "image/png"
+            "src": "/favicon.svg",
+            "sizes": "any",
+            "type": "image/svg+xml"
         }
     ],
     "theme_color": "#000000",


### PR DESCRIPTION
## Summary
- Replaced references to missing `android-chrome-192x192.png` and `android-chrome-512x512.png` with the existing `favicon.svg`
- SVG icons with `sizes="any"` scale to all resolutions

## Test plan
- [ ] Verify manifest loads without 404 errors in DevTools > Application

Closes #5