### PR TITLE
Set browser tab title for individual note posts

### DIFF
--- a/src/pages/NotePost.tsx
+++ b/src/pages/NotePost.tsx
@@ -32,6 +32,8 @@ const NotePost = () => {
       return;
     }
 
+    document.title = `N.R Dhanawada - ${post.title}`;
+
     const loadContent = async () => {
       const filePath = `/src/content/posts/${post.slug}.md`;
       const loader = markdownFiles[filePath];


### PR DESCRIPTION
## Summary
- Added `document.title` update in the `NotePost` component's existing `useEffect`
- Navigating to `/notes/first-principles-in-system-design` now shows "N.R Dhanawada - First Principles in System Design" in the browser tab
- The `TitleUpdater` in App.tsx continues to handle all static routes; this handles the dynamic `/notes/:slug` case

## Test plan
- [ ] Navigate to a note post and verify the browser tab shows the post title
- [ ] Navigate away and verify the title resets to the correct page title

Closes #9