### PR TITLE
Add system theme detection via prefers-color-scheme

### DIFF
--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -16,7 +16,8 @@ interface ThemeProviderProps {
 export const ThemeProvider = ({ children }: ThemeProviderProps) => {
   const [theme, setTheme] = useState<Theme>(() => {
     const stored = localStorage.getItem('theme');
-    return (stored === 'dark' || stored === 'light') ? stored : 'light';
+    if (stored === 'dark' || stored === 'light') return stored;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- When no theme is saved in `localStorage`, the app now checks `window.matchMedia('(prefers-color-scheme: dark)')` to respect the user's OS preference
- Previously it always defaulted to light theme

## Test plan
- [ ] Clear `localStorage` theme key, set OS to dark mode — app should start in dark mode
- [ ] Clear `localStorage` theme key, set OS to light mode — app should start in light mode
- [ ] With an existing `localStorage` theme value, OS preference should be ignored

Closes #10