### PR TITLE
Add Orange Is the New Black to rewatch shows

### DIFF
--- a/src/data/watchlist.ts
+++ b/src/data/watchlist.ts
@@ -19,6 +19,7 @@ export const WATCHLIST_MEDIA: MediaEntry[] = [
   { id: 2691, type: 'tv', category: 'rewatch' },    // Two and a Half Men
   { id: 1668, type: 'tv', category: 'rewatch' },    // Friends
   { id: 62320, type: 'tv', category: 'rewatch' },   // Grace and Frankie
+  { id: 1424, type: 'tv', category: 'rewatch' },    // Orange Is the New Black
 
   // All-time Favorites
   { id: 120, type: 'movie', category: 'favorite' },   // LOTR: Fellowship


### PR DESCRIPTION
## Summary
- Added Orange Is the New Black (TMDB ID 1424) to the Dinner & Lunch Rewatch Shows category

## Test plan
- [ ] Verify the show appears in the rewatch section on the /tv page